### PR TITLE
Fix #14

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.99.552
+current_version = 0.99.553
 commit = True
 commit_args = --no-verify
 tag = True

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.99.554
+current_version = 0.99.555
 commit = True
 commit_args = --no-verify
 tag = True

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.99.553
+current_version = 0.99.554
 commit = True
 commit_args = --no-verify
 tag = True

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+tests/fixtures/**/* -diff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,12 +91,12 @@ repos:
     -   id: style_files
         name: Apply bioconductor style
         entry: >
-            Rscript -e "styler::style_pkg(transformers = styler::tidyverse_style(indent_by = 4))"
+            Rscript --vanilla -e "styler::style_pkg(transformers = styler::tidyverse_style(indent_by = 4))"
         language: system
     -   id: lint_files
         name: Apply lintr
         entry: >
-            Rscript -e "lintr::lint_package()"
+            Rscript --vanilla -e "lintr::lint_package()"
         language: system
     -   id: forbid-to-commit
         name: Don't commit common R artifacts
@@ -107,7 +107,7 @@ repos:
     -   id: codemeta-json-updated
         name: Update codemeta.json
         entry: >
-          Rscript -e "codemetar::write_codemeta(force_update = FALSE)"
+          Rscript --vanilla -e "codemetar::write_codemeta(force_update = FALSE)"
         language: system
         files: DESCRIPTION
         stages: [commit]

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.554
+Version: 0.99.555
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,9 @@ Suggests:
     devtools,
     knitr,
     rmarkdown,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    vcr (>= 0.6.0),
+    webmockr
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.552
+Version: 0.99.553
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.553
+Version: 0.99.554
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/R/get_concordants.R
+++ b/R/get_concordants.R
@@ -63,30 +63,8 @@ get_concordants <- function(signature, ilincs_library = "CP", sig_direction = NU
                 pValue = round(.data[["pValue"]], 20L),
                 sig_direction = sig_direction
             )
-    } else if (ilincs_library %in% c("OE", "KD")) {
-        concordants <- tibble::tibble(
-            signatureid = NA,
-            treatment = NA,
-            time = NA,
-            cellline = NA,
-            similarity = NA,
-            pValue = NA,
-            sig_drection = NA
-        ) %>%
-            dplyr::filter(!is.na(.data[["signatureid"]]))
+        return(concordants)
     } else {
-        concordants <- tibble::tibble(
-            signatureid = NA,
-            compound = NA,
-            concentration = NA,
-            time = NA,
-            cellline = NA,
-            similarity = NA,
-            pValue = NA,
-            sig_drection = NA
-        ) %>%
-            dplyr::filter(!is.na(.data[["signatureid"]]))
+        httr::stop_for_status(request, "get concardant signatures")
     }
-
-    concordants
 }

--- a/R/get_signature.R
+++ b/R/get_signature.R
@@ -42,6 +42,6 @@ get_signature <- function(sig_id, l1000 = TRUE) {
             )
         signature
     } else {
-        stop("Error: ", httr::status_code(request))
+        stop("Error: ", httr::status_code(request), " ", httr::content(request))
     }
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.554",
+  "version": "0.99.555",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/codemeta.json
+++ b/codemeta.json
@@ -138,6 +138,31 @@
         "url": "https://cran.r-project.org"
       },
       "sameAs": "https://CRAN.R-project.org/package=testthat"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "vcr",
+      "name": "vcr",
+      "version": ">= 0.6.0",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=vcr"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "webmockr",
+      "name": "webmockr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=webmockr"
     }
   ],
   "softwareRequirements": {
@@ -265,7 +290,7 @@
   "applicationCategory": "Genomics",
   "isPartOf": "https://bioconductor.org",
   "keywords": ["LINCS", "iLINCS", "drugrepurposing", "drugdiscovery", "transcriptomics", "geneexpression", "geneknockdown", "geneoverexpression", "chemicalperturbagen", "drugfindR", "r", "ilincs", "bioinformatics", "bioinformatics-pipeline"],
-  "fileSize": "1205.097KB",
+  "fileSize": "1848.598KB",
   "releaseNotes": "https://github.com/CogDisResLab/drugfindR/blob/master/NEWS.md",
   "readme": "https://github.com/CogDisResLab/drugfindR/blob/main/README.md"
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.553",
+  "version": "0.99.554",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.552",
+  "version": "0.99.553",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -2295,6 +2295,7 @@ DESVENLAFAXINE
 DET
 DEUP
 Devazepide
+developmentStatus
 devtools
 dexamethasone
 Dexamethasone
@@ -8250,6 +8251,7 @@ RUVBL
 Ruxolitinib
 RVX
 RWDD
+rworkflows
 RWT
 rx
 RXFP
@@ -9922,6 +9924,7 @@ VCL
 VCP
 VCPIP
 VCPKMT
+vcr
 vcs
 VCX
 VCY
@@ -10042,6 +10045,7 @@ WDPCP
 WDR
 WDSUB
 WDTC
+webmockr
 WFDC
 WFIKKN
 WFS
@@ -10159,6 +10163,7 @@ ylsulfonamido
 ylsulfonylphenyl
 YM
 YME
+yml
 ynyl
 YOD
 Yohimbine

--- a/renv.lock
+++ b/renv.lock
@@ -559,6 +559,21 @@
       ],
       "Hash": "93762d0a34d78e6a025efdbfb5c6bb41"
     },
+    "crul": {
+      "Package": "crul",
+      "Version": "1.4.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R6",
+        "curl",
+        "httpcode",
+        "jsonlite",
+        "mime",
+        "urltools"
+      ],
+      "Hash": "1eb00a531331c91d970f3af74b75321f"
+    },
     "curl": {
       "Package": "curl",
       "Version": "5.0.2",
@@ -791,6 +806,18 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "f7736a18de97dea803bde0a2daaafb27"
+    },
+    "fauxpas": {
+      "Package": "fauxpas",
+      "Version": "0.5.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R6",
+        "httpcode",
+        "whisker"
+      ],
+      "Hash": "303b6f3bf647befbdf64394a1900b6c9"
     },
     "fontawesome": {
       "Package": "fontawesome",
@@ -1086,6 +1113,13 @@
         "yaml"
       ],
       "Hash": "a865aa85bcb2697f47505bfd70422471"
+    },
+    "httpcode": {
+      "Package": "httpcode",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "13641a1c6d2cc98801b76764078e17ea"
     },
     "httpuv": {
       "Package": "httpuv",
@@ -2162,6 +2196,16 @@
       ],
       "Hash": "0c41a73214d982f539c56a7773c7afa5"
     },
+    "triebeard": {
+      "Package": "triebeard",
+      "Version": "0.4.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "Rcpp"
+      ],
+      "Hash": "642507a148b0dd9b5620177e0a044413"
+    },
     "tzdb": {
       "Package": "tzdb",
       "Version": "0.4.0",
@@ -2186,6 +2230,19 @@
         "xml2"
       ],
       "Hash": "409328b8e1253c8d729a7836fe7f7a16"
+    },
+    "urltools": {
+      "Package": "urltools",
+      "Version": "1.7.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "methods",
+        "triebeard"
+      ],
+      "Hash": "e86a704261a105f4703f653e05defa3e"
     },
     "usethis": {
       "Package": "usethis",
@@ -2237,6 +2294,23 @@
         "R"
       ],
       "Hash": "3d78edfb977a69fc7a0341bee25e163f"
+    },
+    "vcr": {
+      "Package": "vcr",
+      "Version": "1.2.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R6",
+        "base64enc",
+        "crul",
+        "httr",
+        "rprojroot",
+        "urltools",
+        "webmockr",
+        "yaml"
+      ],
+      "Hash": "7cb7298ab402fca46f635fb5c9304c14"
     },
     "vctrs": {
       "Package": "vctrs",
@@ -2304,6 +2378,23 @@
         "tibble"
       ],
       "Hash": "2c993415154cdb94649d99ae138ff5e5"
+    },
+    "webmockr": {
+      "Package": "webmockr",
+      "Version": "0.9.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R6",
+        "base64enc",
+        "crul",
+        "curl",
+        "fauxpas",
+        "jsonlite",
+        "magrittr",
+        "urltools"
+      ],
+      "Hash": "2f97808043100cbe30e3cbb1e751f8db"
     },
     "whisker": {
       "Package": "whisker",

--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -1,0 +1,5 @@
+library("vcr") # *Required* as vcr is set up on loading
+invisible(vcr::vcr_configure(
+    dir = vcr::vcr_test_path("cassettes")
+))
+vcr::check_cassette_names()

--- a/tests/testthat/test-get_concordants.R
+++ b/tests/testthat/test-get_concordants.R
@@ -6,11 +6,19 @@ test_that("Input signature must be a data frame or data frame like object", {
     expect_error(get_concordants("LINCSKD_28"))
 })
 
-test_that("library must be one of 'OE', 'KD' or 'CP'", {
+test_that("Library must be one of 'OE', 'KD' or 'CP'", {
     expect_error(get_concordants(example_signature(), "INVALID"))
 })
 
 # Test invalid signature
+
+test_that("Function errors if it receives an error response", {
+    webmockr::stub_request("post", "http://www.ilincs.org/api/SignatureMeta/uploadAndAnalyze") %>%
+        webmockr::to_return(status = 500L)
+    webmockr::httr_mock()
+    expect_error(get_concordants(example_signature()))
+    webmockr::httr_mock(FALSE)
+})
 
 
 # Test valid signature


### PR DESCRIPTION
- build: add vcr and webmockr as dependencies
- Bump version: 0.99.552 → 0.99.553
- feat(get_concordants): return error on API connection failures
- Bump version: 0.99.553 → 0.99.554
- fix: return a more informative error on `get_signature`
- Bump version: 0.99.554 → 0.99.555
